### PR TITLE
allow damaged files to be displayed

### DIFF
--- a/Data/MidiData.cs
+++ b/Data/MidiData.cs
@@ -105,7 +105,7 @@ namespace JeffBourdier
             {
                 if ((index + i) >= bytes.Length)
                 {
-                    throw new ApplicationException(Properties.Resources.InvalidVLQ +String.Format(" offset {0}",index+i));
+                    throw new ApplicationException(Properties.Resources.InvalidVLQ + string.Format(" offset {0}", index + i));
                 }
 
                 /* As appropriate, initialize the result (or shift it seven bits

--- a/Data/MidiData.cs
+++ b/Data/MidiData.cs
@@ -100,8 +100,14 @@ namespace JeffBourdier
             /* A variable-length quantity is in big-endian order, and only the lowest seven bits of each byte are part of the
              * quantity.  The Most Significant Bit (MSB) is set in all bytes except the last.  It can be up to four bytes long.
              */
+
             for (int i = 0, n = 0; i < 4; ++i)
             {
+                if ((index + i) >= bytes.Length)
+                {
+                    throw new ApplicationException(Properties.Resources.InvalidVLQ +String.Format(" offset {0}",index+i));
+                }
+
                 /* As appropriate, initialize the result (or shift it seven bits
                  * to the left) and add to it the lowest seven bits of this byte.
                  */

--- a/Data/Sets/MidiFile.cs
+++ b/Data/Sets/MidiFile.cs
@@ -44,7 +44,7 @@ namespace JeffBourdier
             }
             catch (Exception ex)
             {
-                this.CreationException = ex;
+                CreationException = ex;
             }
         }
 

--- a/Data/Sets/MidiFile.cs
+++ b/Data/Sets/MidiFile.cs
@@ -25,6 +25,8 @@ namespace JeffBourdier
     /// <summary>Represents a standard MIDI file (essentially, a collection of MidiChunk objects).</summary>
     public class MidiFile : MidiSet
     {
+
+ 
         /****************
          * Constructors *
          ****************/
@@ -36,7 +38,14 @@ namespace JeffBourdier
         public MidiFile(string filePath) : base(new List<MidiChunk>())
         {
             byte[] bytes = File.ReadAllBytes(filePath);
-            this.Replace(bytes);
+            try
+            {
+                this.Replace(bytes);
+            }
+            catch (Exception ex)
+            {
+                this.CreationException = ex;
+            }
         }
 
         /// <summary>Initializes a new instance of the MidiFile class with a header (MThd) chunk.</summary>
@@ -54,6 +63,9 @@ namespace JeffBourdier
          ***********/
 
         #region Public Methods
+
+        public Exception CreationException { get; set; }
+
 
         /// <summary>Gets the chunk at the specified index.</summary>
         /// <param name="index">The zero-based index of the chunk to get.</param>

--- a/MIDIopsyWindow.cs
+++ b/MIDIopsyWindow.cs
@@ -276,6 +276,11 @@ namespace JeffBourdier
                 return false;
             }
 
+            if (!(this.MidiFile.CreationException==null)){
+                MessageBox.Show(String.Format("warning: {0}", this.MidiFile.CreationException.Message), Meta.Name, MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+
             /* Load the file object into the UI. */
             this.LoadFile();
             return true;


### PR DESCRIPTION
When there's an exception when parsing a file, the error is displayed and parsing stops but however much of the file that was already parsed can still be viewed.

Also made a (somewhat?) more informative error message when a VLQ read goes past the end of the file.